### PR TITLE
Update the mkdir for wpmvc/cache to be recursive so as to avoid Fatal error

### DIFF
--- a/src/psr4/drivers/files.php
+++ b/src/psr4/drivers/files.php
@@ -20,8 +20,6 @@ class phpfastcache_files extends BasePhpFastCache implements phpfastcache_driver
     function checkdriver() {
         if(is_writable($this->getPath())) {
             return true;
-        } else {
-
         }
         return false;
     }
@@ -63,7 +61,7 @@ class phpfastcache_files extends BasePhpFastCache implements phpfastcache_driver
          */
         if($skip == false) {
             if(!@file_exists($path)) {
-                if(!@mkdir($path,$this->__setChmodAuto())) {
+                if(!@mkdir($path, $this->__setChmodAuto(), true)) {
                     throw new Exception("PLEASE CHMOD ".$this->getPath()." - 0777 OR ANY WRITABLE PERMISSION!",92);
                 }
 

--- a/src/psr4/phpFastCache.php
+++ b/src/psr4/phpFastCache.php
@@ -145,10 +145,10 @@ class phpFastCache
 
             if(!@file_exists($full_path) || !@is_writable($full_path)) {
                 if(!@file_exists($full_path)) {
-                    @mkdir($full_path,self::__setChmodAuto($config));
+                    @mkdir($full_path, self::__setChmodAuto($config), true);
                 }
                 if(!@is_writable($full_path)) {
-                    @chmod($full_path,self::__setChmodAuto($config));
+                    @chmod($full_path, self::__setChmodAuto($config));
                 }
                 if(!@file_exists($full_path) || !@is_writable($full_path)) {
 					throw new Exception('PLEASE CREATE OR CHMOD '.$full_path.' - 0777 OR ANY WRITABLE PERMISSION!',92);

--- a/src/psr4/phpFastCache.php
+++ b/src/psr4/phpFastCache.php
@@ -25,33 +25,33 @@ class phpFastCache
 		/*
 		 * Fall back when old driver is not support
 		 */
-		'fallback'  => 'files',
+		'fallback'      => 'files',
 
 		'securityKey'   =>  'auto',
 		'htaccess'      => true,
-		'path'      =>  '',
+		'path'          =>  '',
 
-		'memcache'        =>  array(
+		'memcache'      =>  array(
 			array('127.0.0.1',11211,1),
 			//  array('new.host.ip',11211,1),
 		),
 
 		'redis'         =>  array(
-			'host'  => '127.0.0.1',
-			'port'  =>  '',
+			'host'      => '127.0.0.1',
+			'port'      =>  '',
 			'password'  =>  '',
 			'database'  =>  '',
 			'timeout'   =>  ''
 		),
 
         'ssdb'         =>  array(
-			'host'  => '127.0.0.1',
-			'port'  =>  8888,
-			'password'  =>  '',
-			'timeout'   =>  ''
+			'host'     => '127.0.0.1',
+			'port'     =>  8888,
+			'password' =>  '',
+			'timeout'  =>  ''
 		),
 
-		'extensions'    =>  array(),
+		'extensions'   =>  array(),
 	);
 
     protected static $tmp = array();
@@ -71,13 +71,9 @@ class phpFastCache
         $this->instance = phpFastCache($storage,$config);
     }
 
-
-
-
     public function __call($name, $args) {
         return call_user_func_array(array($this->instance, $name), $args);
     }
-
 
     /*
      * Cores
@@ -105,14 +101,11 @@ class phpFastCache
             $driver = 'files';
         }
 
-
         return $driver;
-
     }
 
     public static function getPath($skip_create_path = false, $config) {
-        if ( !isset($config['path']) || $config['path'] == '' )
-        {
+        if ( !isset($config['path']) || $config['path'] == '' ) {
 
             // revision 618
             if(self::isPHPModule()) {
@@ -182,10 +175,10 @@ class phpFastCache
 
     protected static function getOS() {
         $os = array(
-            'os' => PHP_OS,
-            'php' => PHP_SAPI,
-            'system'    => php_uname(),
-            'unique'    => md5(php_uname().PHP_OS.PHP_SAPI)
+            'os'     => PHP_OS,
+            'php'    => PHP_SAPI,
+            'system' => php_uname(),
+            'unique' => md5(php_uname().PHP_OS.PHP_SAPI)
         );
         return $os;
     }
@@ -250,6 +243,5 @@ allow from 127.0.0.1';
     public static function required($class) {
         require_once(dirname(__FILE__).'/drivers/'.$class.'.php');
     }
-
 
 }


### PR DESCRIPTION
👋  @amostajo

With the current setup of the WPMVC framework the WPMVC-PHPFastCache module attempts to create the wp-content/wpmvc/cache folder due to the default path setup;
https://github.com/10quality/wpmvc/blob/v2.0/app/Config/app.php#L72

During this process it needs to recursively create the wpmvc and cache folders, the fast cache module though doesn't set the recursive flag on it's mkdir call;
https://github.com/10quality/wpmvc-phpfastcache/blob/v4.0/src/psr4/phpFastCache.php#L155

As the recursive flag isn't set the mkdir fails and so the exception is thrown as a fatal error;
```
[error] 27547#27547: *4755016 FastCGI sent in stderr: "PHP message: PHP Fatal error: Uncaught Exception: PLEASE CREATE OR CHMOD /var/www/html/wordpress/wp-content/wpmvc/cache/stnvideoca/ - 0777 OR ANY WRITABLE PERMISSION! in /var/www/html/wordpress/wp-content/plugins/sendtonews/vendor/10quality/wpmvc-phpfastcache/src/psr4/phpFastCache.php:161
Stack trace:
#0 /var/www/html/wordpress/wp-content/plugins/sendtonews/vendor/10quality/wpmvc-phpfastcache/src/psr4/phpFastCache.php(89): WPMVC\PHPFastCache\phpFastCache::getPath(false, Array)
#1 /var/www/html/wordpress/wp-content/plugins/sendtonews/vendor/10quality/wpmvc-phpfastcache/src/lib/functions.php(26): WPMVC\PHPFastCache\phpFastCache::getAutoClass(Array)
#2 /var/www/html/wordpress/wp-content/plugins/sendtonews/vendor/10quality/wpmvc-core/src/psr4/Cache.php(50): phpFastCache()
#3 /var/www/html/wordpress/wp-content/plugins/sendtonews/vendor/10quality/wpmvc-core/src/psr4/Cache.php(62): WPMVC\Cache->__construct(Object(WPMVC\Config))
#4 /var/www/html/wordpress/wp-content/plugins/sendtonews/vendor/10quali" while reading response header from upstream, client: 2601:46:c802:8d10:493a:fd50:c2e4:cd1d, server: *.stnvideo.ca, request: "GET /favicon.ico HTTP/1.1", upstream: "fastcgi://127.0.0.1:9000", host: "www.stnvideo.ca", referrer: "https://www.stnvideo.ca/"
```

For our client this occurred on their local NGINX install, I was able to reproduce using Local by Flywheel on Apache as well.

To avoid the fatal error testing I found just setting the recursive flag on the mkdir call was sufficient, hence this PR.

Along with setting the recursive flag I did a minor CS update, feel free to drop that and just set the flag.

Appreciate you taking a look into addressing this as I'd like to avoid forking and changing the stack.