### PR TITLE
Switch from \r\n to PHP_EOL for the end of line character to be better cross-server compatible.

### DIFF
--- a/src/psr4/BasePhpFastCache.php
+++ b/src/psr4/BasePhpFastCache.php
@@ -317,13 +317,10 @@ abstract class BasePhpFastCache {
         if($this->option('htaccess') == true) {
 
             if(!File::auth()->exists($path."/.htaccess")) {
-                //   echo "write me";
-                $html = "order deny, allow \r\n
-deny from all \r\n
-allow from 127.0.0.1";
+                $html = 'order deny, allow' . PHP_EOL;
+                $html .= 'deny from all' . PHP_EOL;
+                $html .= 'allow from 127.0.0.1' . PHP_EOL;
                 File::auth()->write($path.'/.htaccess', $html);
-            } else {
-                //   echo "got me";
             }
         }
     }

--- a/src/psr4/phpFastCache.php
+++ b/src/psr4/phpFastCache.php
@@ -217,9 +217,9 @@ class phpFastCache
             }
             $file = File::auth();
             if(!$file->exists($path.'/.htaccess')) {
-                $html = 'order deny, allow \r\n
-deny from all \r\n
-allow from 127.0.0.1';
+                $html = 'order deny, allow' . PHP_EOL;
+                $html .= 'deny from all' . PHP_EOL;
+                $html .= 'allow from 127.0.0.1' . PHP_EOL;
                 $file->write($path.'/.htaccess', $html);
             }
         }
@@ -234,7 +234,7 @@ allow from 127.0.0.1';
     }
 
     public static function debug($something) {
-        echo 'Starting Debugging ...<br>\r\n ';
+        echo 'Starting Debugging ...<br>' . PHP_EOL;
         if(is_array($something)) {
             echo '<pre>';
             print_r($something);
@@ -243,7 +243,7 @@ allow from 127.0.0.1';
         } else {
             echo $something;
         }
-        echo '\r\n<br> Ended';
+        echo PHP_EOL . '<br> Ended';
         exit;
     }
 


### PR DESCRIPTION
This PR updated the .htaccess creation to use proper PHP_EOL for new lines instead of `\r\n` as that will just print out as is on mac localhost and some nginx servers.
```
order deny, allow \r\n
deny from all \r\n
allow from 127.0.0.1
```

I didn't touch the `\r\n` instances inside the CompositeStreamConnection.php, StreamConnection.php or RequestSerializer.php as my focus was on the htaccess file. These files also use the server specific `\r\n` newline.