### PR TITLE
Update default CHMOD permissions to match WP and it's use of FS_CHMOD_DIR

### DIFF
--- a/src/psr4/drivers/files.php
+++ b/src/psr4/drivers/files.php
@@ -64,12 +64,12 @@ class phpfastcache_files extends BasePhpFastCache implements phpfastcache_driver
         if($skip == false) {
             if(!@file_exists($path)) {
                 if(!@mkdir($path,$this->__setChmodAuto())) {
-                    throw new Exception("PLEASE CHMOD ".$this->getPath()." - 0777 OR ANY WRITABLE PERMISSION!",92);
+                    throw new Exception("PLEASE CHMOD ".$this->getPath()." to ".self::__setChmodAuto($config)." OR ANY WRITABLE PERMISSION!",92);
                 }
 
             } elseif(!is_writeable($path)) {
                 if(!chmod($path,$this->__setChmodAuto())) {
-                    throw new Exception("PLEASE CHMOD ".$this->getPath()." - 0777 OR ANY WRITABLE PERMISSION!",92);
+                    throw new Exception("PLEASE CHMOD ".$this->getPath()." to ".self::__setChmodAuto($config)." OR ANY WRITABLE PERMISSION!",92);
                 }
             }
         }

--- a/src/psr4/phpFastCache.php
+++ b/src/psr4/phpFastCache.php
@@ -21,7 +21,7 @@ class phpFastCache
     public static $disabled = false;
 	public static $config = array(
         'storage'       =>  '', // blank for auto
-        'default_chmod' =>  0777, // 0777 , 0666, 0644
+        'default_chmod' =>  FS_CHMOD_DIR, // fileperms( ABSPATH ) & 0777 | 0755
 		/*
 		 * Fall back when old driver is not support
 		 */
@@ -158,7 +158,7 @@ class phpFastCache
                     @chmod($full_path,self::__setChmodAuto($config));
                 }
                 if(!@file_exists($full_path) || !@is_writable($full_path)) {
-					throw new Exception('PLEASE CREATE OR CHMOD '.$full_path.' - 0777 OR ANY WRITABLE PERMISSION!',92);
+					throw new Exception('PLEASE CREATE OR CHMOD '.$full_path.' to '.self::__setChmodAuto($config).' OR ANY WRITABLE PERMISSION!',92);
                 }
             }
 
@@ -174,7 +174,7 @@ class phpFastCache
 
     public static function __setChmodAuto($config) {
         if(!isset($config['default_chmod']) || $config['default_chmod'] == '' || is_null($config['default_chmod'])) {
-            return 0777;
+            return FS_CHMOD_DIR;
         } else {
             return $config['default_chmod'];
         }
@@ -209,10 +209,10 @@ class phpFastCache
         if($create == true) {
             if(!is_writeable($path)) {
                 try {
-                    chmod($path,0777);
+                    chmod($path,self::__setChmodAuto($config));
                 }
                 catch(Exception $e) {
-					throw new Exception('PLEASE CHMOD '.$path.' - 0777 OR ANY WRITABLE PERMISSION!',92);
+					throw new Exception('PLEASE CHMOD '.$path.' to '.self::__setChmodAuto($config).' OR ANY WRITABLE PERMISSION!',92);
                 }
             }
             $file = File::auth();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 define('TMP_PATH', __DIR__.'/../.tmp');
-define('FS_CHMOD_FILE', '0777');
+define('ABSPATH', __DIR__ . '/');
+define('FS_CHMOD_FILE', fileperms( ABSPATH ) & 0777 | 0755 ));
 require_once __DIR__.'/../vendor/autoload.php';
 // Load vendor required classes and functions
 require_once __DIR__.'/../vendor/10quality/wp-file/tests/framework/wp-functions.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,7 +1,6 @@
 <?php
 define('TMP_PATH', __DIR__.'/../.tmp');
-define('ABSPATH', __DIR__ . '/');
-define('FS_CHMOD_FILE', fileperms( ABSPATH ) & 0777 | 0755 ));
+define('FS_CHMOD_FILE', '0777');
 require_once __DIR__.'/../vendor/autoload.php';
 // Load vendor required classes and functions
 require_once __DIR__.'/../vendor/10quality/wp-file/tests/framework/wp-functions.php';


### PR DESCRIPTION
A client flagged the use of 0777 for folder creation as something their security team frowns upon.

This PR updates the WPMVC-PHPFastCache module to adhere to WP file permissions use of the FS_CHMOD_DIR;
https://wpseek.com/constant/fs_chmod_dir/

Also updated the error messages to use the default config incase the config overrides the constant.